### PR TITLE
Games: Entities: GetProcProperties: Early exit if source has no proc properties

### DIFF
--- a/src/MHServerEmu.Games/Entities/WorldEntity.Procs.cs
+++ b/src/MHServerEmu.Games/Entities/WorldEntity.Procs.cs
@@ -127,6 +127,12 @@ namespace MHServerEmu.Games.Entities
 
             // Copy proc properties to a temporary collection for iteration
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                // No proc properties - still need to handle cancel-on-proc-trigger conditions
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
 
             // Non-keyword procs
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
@@ -247,6 +253,12 @@ namespace MHServerEmu.Games.Entities
             Vector3 targetPosition = target != null ? target.RegionLocation.Position : collisionPosition;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
             {
                 if (CheckProc(kvp, out Power procPower) == false)
@@ -273,6 +285,8 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(condition.Properties);
+            if (procProperties == null)
+                return;
 
             // Run common proc logic
             TryActivateProcsCommon(ProcTriggerType.OnConditionEnd, procProperties);
@@ -310,6 +324,9 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(condition.Properties);
+            if (procProperties == null)
+                return;
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnConditionStackCount))
             {
                 if (CheckProc(kvp, out Power procPower, param) == false)
@@ -342,6 +359,12 @@ namespace MHServerEmu.Games.Entities
             }
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnDeath);
+                return;
+            }
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnDeath))
             {
                 if (CheckProc(kvp, out Power procPower) == false)
@@ -410,6 +433,9 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+                return;
+
             foreach (var kvp in procProperties)
             {
                 Property.FromParam(kvp.Key, 0, out int triggerTypeValue);
@@ -455,6 +481,9 @@ namespace MHServerEmu.Games.Entities
             WorldEntity target = Game.EntityManager.GetEntity<WorldEntity>(powerResults.UltimateOwnerId);
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+                return;
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnGotAttacked))
             {
                 if (CheckProc(kvp, out Power procPower) == false)
@@ -521,6 +550,11 @@ namespace MHServerEmu.Games.Entities
             };
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
 
             // Non-keyworded procs
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
@@ -602,6 +636,9 @@ namespace MHServerEmu.Games.Entities
             int param = (int)(MathHelper.Ratio(Properties[PropertyEnum.Health], healthMax) * 100f);
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+                return true;
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc))
             {
                 Property.FromParam(kvp.Key, 0, out int triggerTypeValue);
@@ -682,6 +719,7 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnInCombatProcs()    // 32
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnInCombat, procProperties);
         }
 
@@ -694,6 +732,12 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
             {
                 if (CheckProc(kvp, out Power procPower) == false)
@@ -742,6 +786,11 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
 
             // Non-keyworded procs
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
@@ -845,31 +894,40 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnKnockdownEndProcs()    // 40
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnKnockdownEnd, procProperties);
         }
 
         public void TryActivateOnLifespanExpiredProcs() // 41
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnLifespanExpired, procProperties);
         }
 
         public void TryActivateOnLootPickupProcs(WorldEntity item)  // 42
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnLootPickup, procProperties, item);
         }
 
         public void TryActivateOnMissileAbsorbedProcs() // 43
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnMissileAbsorbed, procProperties);
         }
 
         public void TryActivateOnMovementStartedProcs() // 44
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
-            
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnMovementStarted);
+                return;
+            }
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnMovementStarted))
             {
                 if (CheckProc(kvp, out Power procPower) == false)
@@ -893,6 +951,11 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnMovementStoppedProcs() // 45
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnMovementStopped);
+                return;
+            }
 
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnMovementStopped))
             {
@@ -917,12 +980,14 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnNegStatusAppliedProcs()  // 46
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnNegStatusApplied, procProperties);
         }
 
         public void TryActivateOnOrbPickupProcs(Agent orb)  // 47
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
 
             // Non-keyworded procs
             TryActivateProcsCommon(ProcTriggerType.OnOrbPickup, procProperties);
@@ -953,6 +1018,7 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnOutCombatProcs() // 48
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnOutCombat, procProperties);
         }
 
@@ -962,6 +1028,12 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnOverlapBegin);
+                return;
+            }
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnOverlapBegin))
                 TryActivateOnOverlapBeginProcHelper(kvp, target, overlapPosition);
 
@@ -1015,6 +1087,7 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnPetDeathProcs(WorldEntity pet)  // 50
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
 
             // Non-keyworded procs
             TryActivateProcsCommon(ProcTriggerType.OnPetDeath, procProperties);
@@ -1056,6 +1129,11 @@ namespace MHServerEmu.Games.Entities
             float procChanceMultiplier = powerProto.OnHitProcChanceMultiplier;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnPetHit);
+                return;
+            }
 
             // Non-keyworded procs
             foreach (var kvp in procProperties.IteratePropertyRange(Property.ProcPropertyTypesAll))
@@ -1119,6 +1197,11 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
 
             // Non-keyworded procs
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
@@ -1182,6 +1265,7 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnRunestonePickupProcs()
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnRunestonePickup, procProperties);
         }
 
@@ -1193,6 +1277,7 @@ namespace MHServerEmu.Games.Entities
             if (newValue == 0f)
             {
                 using PropertyCollection procProperties = GetProcProperties(Properties);
+                if (procProperties == null) return;
                 TryActivateProcsCommon(ProcTriggerType.OnSecondaryResourceEmpty, procProperties);
             }
         }
@@ -1203,6 +1288,7 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
 
             if (newPips > oldPips)
                 TryActivateProcsCommon(ProcTriggerType.OnSecondaryResourcePipGain, procProperties);
@@ -1218,12 +1304,14 @@ namespace MHServerEmu.Games.Entities
         public void TryActivateOnSkillshotReflectProcs()   // 69
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
             TryActivateProcsCommon(ProcTriggerType.OnSkillshotReflect, procProperties);
         }
 
         public void TryActivateOnSummonPetProcs(WorldEntity pet)   // 70
         {
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
 
             // Non-keyworded procs
             TryActivateProcsCommon(ProcTriggerType.OnSummonPet, procProperties);
@@ -1255,7 +1343,8 @@ namespace MHServerEmu.Games.Entities
         {
             float procChanceMultiplier = power.Prototype.OnHitProcChanceMultiplier;
 
-            using PropertyCollection procProperties = ObjectPoolManager.Instance.Get<PropertyCollection>();
+            using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null) return;
 
             // Non-keyworded procs
             TryActivateProcsCommon(ProcTriggerType.OnMissileHit, procProperties, null, procChanceMultiplier);
@@ -1293,6 +1382,12 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnHotspotNegated);
+                return;
+            }
+
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnHotspotNegated))
             {
                 if (CheckProc(kvp, out Power procPower) == false)
@@ -1323,6 +1418,11 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(ProcTriggerType.OnControlledEntityReleased);
+                return;
+            }
 
             // Non-keyworded procs
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)ProcTriggerType.OnControlledEntityReleased))
@@ -1410,6 +1510,11 @@ namespace MHServerEmu.Games.Entities
                 return;
 
             using PropertyCollection procProperties = GetProcProperties(Properties);
+            if (procProperties == null)
+            {
+                ConditionCollection?.RemoveCancelOnProcTriggerConditions(triggerType);
+                return;
+            }
 
             // Non-keyworded procs
             foreach (var kvp in procProperties.IteratePropertyRange(PropertyEnum.Proc, (int)triggerType))
@@ -1733,6 +1838,10 @@ namespace MHServerEmu.Games.Entities
 
         private static PropertyCollection GetProcProperties(PropertyCollection source)
         {
+            // Early exit: check if the source has any proc properties before allocating and copying.
+            if (source.HasPropertyInRange(Property.ProcPropertyTypesAll) == false)
+                return null;
+
             PropertyCollection destination = ObjectPoolManager.Instance.Get<PropertyCollection>();
 
             foreach (PropertyEnum propertyEnum in Property.ProcPropertyTypesAll)

--- a/src/MHServerEmu.Games/Entities/WorldEntity.cs
+++ b/src/MHServerEmu.Games/Entities/WorldEntity.cs
@@ -1696,6 +1696,9 @@ namespace MHServerEmu.Games.Entities
             EntityManager entityManager = Game.EntityManager;
 
             using PropertyCollection procProperties = GetProcProperties(properties);
+            if (procProperties == null)
+                return false;
+
             foreach (var kvp in procProperties.IteratePropertyRange(Property.ProcPropertyTypesAll))
             {
                 Property.FromParam(kvp.Key, 1, out PrototypeId procPowerProtoRef);

--- a/src/MHServerEmu.Games/Properties/PropertyCollection.cs
+++ b/src/MHServerEmu.Games/Properties/PropertyCollection.cs
@@ -1484,5 +1484,36 @@ namespace MHServerEmu.Games.Properties
                 CurveId = curveId;
             }
         }
+
+        /// <summary>
+        /// Returns <see langword="true"/> if this <see cref="PropertyCollection"/> contains any properties
+        /// with a <see cref="PropertyEnum"/> matching any value in the provided <see cref="ReadOnlySpan{T}"/>.
+        /// </summary>
+        public bool HasPropertyInRange(ReadOnlySpan<PropertyEnum> propertyEnums)
+        {
+            foreach (PropertyEnum propertyEnum in propertyEnums)
+            {
+                if (HasPropertyInRange(propertyEnum))
+                    return true;
+            }
+        
+            return false;
+        }
+        
+        /// <summary>
+        /// Returns <see langword="true"/> if this <see cref="PropertyCollection"/> contains any properties
+        /// with the specified <see cref="PropertyEnum"/>.
+        /// </summary>
+        public bool HasPropertyInRange(PropertyEnum propertyEnum)
+        {
+            // If IteratePropertyRange for this enum would yield any results, return true.
+            // This is equivalent to checking if the iterator is non-empty, but allows
+            // implementations to use a more efficient check if available (e.g. checking
+            // a bucket or index rather than iterating).
+            foreach (var kvp in IteratePropertyRange(propertyEnum))
+                return true;
+        
+            return false;
+        }
     }
 }


### PR DESCRIPTION
Adds early exit condition on GetProcProperties to reduce property copies when there is no need. this was tested by going through the opening missions on two new accounts up until you get the xp orb from ultron. 

Samples Before
```log
GetProcProperties: 353060486 / 2.53406e+10 samples = 1.39%

  -- Callers (who calls GetProcProperties) --
  110391085  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnHitProcs
  44401259  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnPowerUseProcs
  37007696  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnOverlapBeginProcs
  34467937  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnGotDamagedProcs
  19813077  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnCollideProcs
  16168543  instance bool [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnHealthProcs
  15664152  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnEnduranceProcs
  15344306  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnGotAttackedProcs
  13125695  instance bool [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::UpdateProcEffectPowers
  13109834  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnPetHitProcs
  11873254  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnMovementStartedProcs
   5527564  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnNegStatusAppliedProcs
   3880989  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnMovementStoppedProcs
   3865968  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnKillProcs
   2443843  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnConditionStackCountProcs
   1745078  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnOutCombatProcs
   1623083  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnConditionEndProcs
   1103501  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnInCombatProcs
    935855  instance bool [MHServerEmu.Games] MHServerEmu.Games.Entities.ConditionCollection::AddCondition
    567767  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnDeathProcs
```

Samples After
```log
 GetProcProperties: 346457941 / 3.27409e+10 samples = 1.06%

  -- Callers (who calls GetProcProperties) --
  114940016  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnHitProcs
  44622421  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnPowerUseProcs
  33857202  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnOverlapBeginProcs
  28022373  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnGotDamagedProcs
  24976770  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnCollideProcs
  14851653  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnPetHitProcs
  13729236  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnMissileHitProcs
  13450991  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnEnduranceProcs
  12952874  instance bool [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::UpdateProcEffectPowers
  11845630  instance bool [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnHealthProcs
  10074518  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnGotAttackedProcs
   7432259  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnMovementStoppedProcs
   4962673  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnConditionEndProcs
   4021968  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnMovementStartedProcs
   1900814  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnNegStatusAppliedProcs
   1429315  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnConditionStackCountProcs
   1408711  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnKillProcs
    832008  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnDeathProcs
    617880  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.Agent::OnOverlapBegin
    528629  instance void [MHServerEmu.Games] MHServerEmu.Games.Entities.WorldEntity::TryActivateOnInCombatProcs
```